### PR TITLE
Upozornění na duplikaci prvků při načtení komponent

### DIFF
--- a/amcr_viewer/amcr_dialog.py
+++ b/amcr_viewer/amcr_dialog.py
@@ -263,6 +263,24 @@ class AmcrFilterDialog(QDialog):
         self.chk_komponenty = QCheckBox("Načíst komponenty")
         layout.addWidget(self.chk_komponenty)
 
+        # Warning label
+        self.lbl_komponenty_warning = QLabel(
+            "⚠ Při načtení komponent jsou prostorové prvky duplikovány — "
+            "každý prvek odpovídá jedné komponentě. "
+            "Prostorové analýzy (plochy, počty) mohou být zkreslené."
+        )
+        self.lbl_komponenty_warning.setWordWrap(True)
+        self.lbl_komponenty_warning.setStyleSheet(
+            "color: #8a6d00; background-color: #fff8e1; "
+            "border: 1px solid #ffe082; border-radius: 4px; padding: 6px;"
+        )
+        self.lbl_komponenty_warning.setVisible(False)
+        layout.addWidget(self.lbl_komponenty_warning)
+
+        self.chk_komponenty.toggled.connect(
+            self.lbl_komponenty_warning.setVisible
+        )
+
         # Pushes everything above to the top
         layout.addStretch(1)
 


### PR DESCRIPTION
Po diskusi o způsobu načítání komponent bylo rozhodnuto ponechat stávající přístup (komponenta jako základní prvek), který umožňuje přímé filtrování v QGIS. Nevýhodou tohoto přístupu je duplikace prostorových prvků — každý prvek odpovídá jedné komponentě, nikoli jedné dokumentační jednotce. Tato změna uživatele na toto chování upozorňuje přímo v dialogu.
- Přidán QLabel s varováním pod checkbox „Načíst komponenty" v AmcrFilterDialog
- Varování je výchozně skryté; zobrazí se (a skryje) automaticky při zaškrtnutí/odškrtnutí checkboxu
- Styl: žlutý warning box, zalomení textu

Closes #34 