### PR TITLE
fix: Oprava chyb a optimalizace

### DIFF
--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # 1. Stáhne kód z repozitáře
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # 2. Vytvoří ZIP (předpokládá, že kód je ve složce 'amcr_viewer')
       - name: Zip Plugin
@@ -22,7 +22,7 @@ jobs:
 
       # 3. Nahraje ZIP k Releasu
       - name: Upload Release Asset
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: amcr_viewer.zip

--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # 1. Stáhne kód z repozitáře
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # 2. Vytvoří ZIP (předpokládá, že kód je ve složce 'amcr_viewer')
       - name: Zip Plugin
@@ -22,7 +22,7 @@ jobs:
 
       # 3. Nahraje ZIP k Releasu
       - name: Upload Release Asset
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: amcr_viewer.zip

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Layers are only created if the query returns features of the corresponding geome
 
 The plugin is developed in **Python 3** using the **PyQt6** framework for the GUI and the **Requests** library for HTTP communication.
 
+> **Note:** The `requests` library is bundled with the QGIS installers for Windows and macOS. On Linux (distribution packages), it may need to be installed separately (e.g. `python3-requests`).
+
 ### 4.1 File Structure
 
 * `amcr_viewer.py`: Entry point; handles GUI integration, toolbar/menu setup, and login flow.

--- a/amcr_viewer/amcr_codelists.py
+++ b/amcr_viewer/amcr_codelists.py
@@ -158,6 +158,11 @@ def fetch_set(internal_name, api_set, task=None):
                             ),
                             None
                         )
+                        # Skip records without a valid one-letter code –
+                        # a None code would end up in the CSV and later
+                        # in the API filter as the string "None"
+                        if not kod:
+                            continue
 
                     dataset.append({
                         'Název': nazev,

--- a/amcr_viewer/amcr_dialog.py
+++ b/amcr_viewer/amcr_dialog.py
@@ -7,11 +7,18 @@ from qgis.PyQt.QtWidgets import (QDialog, QVBoxLayout,
 from qgis.PyQt.QtCore import Qt, QSettings
 from qgis.core import (QgsTask, QgsApplication,
                        QgsMessageLog, Qgis, QgsAuthMethodConfig)
+from qgis.utils import iface
 from .amcr_codelists import (OBDOBI, TYP_AKCE, KRAJE, AREAL, ORGANIZACE,
                              OKRESY, KATASTRY, VEDOUCI, PIAN_PRESNOST,
                              TYP_LOKALITY, DRUH_LOKALITY, JISTOTA,
                              LOKALITA_ZACHOVALOST, PRISTUPNOST,
                              download_heslare, refresh_globals)
+
+
+# Keep Python references to running tasks. QgsTaskManager only holds the
+# C++ object; without a Python-side reference the wrapper can be garbage
+# collected before the task finishes, which crashes QGIS.
+_ACTIVE_TASKS = []
 
 
 class UpdateCodelistsTask(QgsTask):
@@ -370,21 +377,38 @@ class AmcrFilterDialog(QDialog):
         return row_widget
 
     def action_update_heslare(self):
-        # Create the task instance
+        # Create the task instance and keep a reference so the Python
+        # wrapper survives until the task finishes
         task = UpdateCodelistsTask("Aktualizace heslářů AMČR")
+        _ACTIVE_TASKS.append(task)
 
-        # Re-enable the button regardless of the outcome
-        task.taskCompleted.connect(lambda: self.btn_update.setEnabled(True))
-        task.taskTerminated.connect(lambda: self.btn_update.setEnabled(True))
+        # Prevent parallel downloads overwriting heslar.csv
+        self.btn_update.setEnabled(False)
 
-        task.taskCompleted.connect(lambda: QMessageBox.information(
-            self,
-            "Hotovo",
-            "Hesláře byly úspěšně aktualizovány."
-        ))
+        # Message boxes are parented to the main window, not to this dialog –
+        # the dialog may already be closed (and its C++ object deleted)
+        # by the time the minute-long task finishes.
+        parent_win = iface.mainWindow() if iface else None
+
+        def _cleanup():
+            if task in _ACTIVE_TASKS:
+                _ACTIVE_TASKS.remove(task)
+            try:
+                self.btn_update.setEnabled(True)
+            except RuntimeError:
+                pass  # dialog already closed
+
+        def on_completed():
+            _cleanup()
+            QMessageBox.information(
+                parent_win,
+                "Hotovo",
+                "Hesláře byly úspěšně aktualizovány."
+            )
 
         # Show the exact error if the task fails
         def on_error():
+            _cleanup()
             if task.exception:
                 # This will show exactly what went wrong (e.g. PermissionError)
                 msg = (
@@ -393,8 +417,9 @@ class AmcrFilterDialog(QDialog):
                 )
             else:
                 msg = "Aktualizace byla zrušena uživatelem."
-            QMessageBox.warning(self, "Chyba / Zrušeno", msg)
+            QMessageBox.warning(parent_win, "Chyba / Zrušeno", msg)
 
+        task.taskCompleted.connect(on_completed)
         task.taskTerminated.connect(on_error)
 
         QgsApplication.taskManager().addTask(task)

--- a/amcr_viewer/amcr_dialog.py
+++ b/amcr_viewer/amcr_dialog.py
@@ -627,6 +627,39 @@ class LoginDialog(QDialog):
 
         return True
 
+    def _verify_credentials(self, username: str, password: str) -> bool:
+        """
+        Verify the credentials against the API before saving them.
+        Returns True if they should be stored: either the login succeeded,
+        or the server was unreachable and the user chose to keep them
+        unverified. Wrong credentials are never stored.
+        """
+        # Lazy import to avoid an import cycle
+        # (amcr_tools imports LoginDialog lazily as well)
+        from . import amcr_tools
+
+        if amcr_tools.login_to_api(username, password):
+            return True
+
+        if amcr_tools.LAST_LOGIN_ERROR == 'network':
+            answer = QMessageBox.question(
+                self,
+                "Server nedostupný",
+                "Přihlašovací údaje se nepodařilo ověřit – server AMČR "
+                "je nedostupný.\nChcete je přesto uložit (neověřené)?",
+                QMessageBox.StandardButton.Yes
+                | QMessageBox.StandardButton.No
+            )
+            return answer == QMessageBox.StandardButton.Yes
+
+        QMessageBox.warning(
+            self,
+            "Neplatné přihlašovací údaje",
+            "Přihlášení se nezdařilo – zkontrolujte e-mail a heslo.\n"
+            "Údaje nebyly uloženy."
+        )
+        return False
+
     # ------------------------------------------------------------------
     # Button actions
     # ------------------------------------------------------------------
@@ -653,6 +686,11 @@ class LoginDialog(QDialog):
             if ok:
                 if not self._ensure_master_password():
                     return
+                # Verify the new username against the stored password
+                if not self._verify_credentials(
+                    username, cfg.config("password", "")
+                ):
+                    return
                 cfg.setConfig("username", username)
                 auth_mgr.updateAuthenticationConfig(cfg)
                 self.accept()
@@ -660,6 +698,11 @@ class LoginDialog(QDialog):
 
         if not password:
             QMessageBox.warning(self, "Chybí údaje", "Vyplňte prosím heslo.")
+            return
+
+        # Verify before prompting for the master password – wrong
+        # credentials must never reach the Authentication Manager
+        if not self._verify_credentials(username, password):
             return
 
         if not self._ensure_master_password():

--- a/amcr_viewer/amcr_tools.py
+++ b/amcr_viewer/amcr_tools.py
@@ -17,6 +17,11 @@ TRANSLATIONS = {}
 # None = not logged in (anonymous access)
 AMCR_SESSION: requests.Session | None = None
 
+# Re-entrancy guard: the download runs in the main thread and pumps the
+# event loop via processEvents(), so the user could otherwise start
+# a second download while the first one is still running
+_LOADING = False
+
 
 def _log(msg: str, level=Qgis.MessageLevel.Info):
     """
@@ -82,6 +87,12 @@ def login_to_api(username: str, password: str):
     except requests.exceptions.RequestException as e:
         _log(f"CHYBA sítě: {e}", Qgis.MessageLevel.Critical)
         return None
+    except ValueError:
+        # Server returned non-JSON (e.g. an HTML error page behind a proxy)
+        _log("CHYBA: server nevrátil platný JSON: "
+             f"{response.text[:300]}",
+             Qgis.MessageLevel.Critical)
+        return None
 
 
 def _get_session() -> requests.Session | None:
@@ -104,33 +115,40 @@ def _get_session() -> requests.Session | None:
     return AMCR_SESSION
 
 
-def _api_get(url, params, timeout=30) -> requests.Response:
+def _api_get_json(url, params, timeout=30) -> dict:
     """
-    Performs a GET request. If the API signals an expired login,
-    re-authenticates once and retries.
+    Performs a GET request and returns the parsed JSON body.
+    If the API signals an expired login, re-authenticates once and retries.
+    The body is parsed exactly once (the auth check reuses it).
+    Raises ValueError if the server does not return valid JSON.
     """
     global AMCR_SESSION
 
-    def _is_auth_error(resp: requests.Response) -> bool:
+    def _is_auth_error(resp: requests.Response, body) -> bool:
         """The API returns auth errors with status 200 –
         the body must be checked."""
         if resp.status_code == 401:
             return True
-        try:
-            body = resp.json()
-            err = str(body.get("error", "")).lower()
-            return (
-                "unauthorized" in err
-                or "not logged" in err
-                or "session" in err
-            )
-        except Exception:
+        if not isinstance(body, dict):
             return False
+        err = str(body.get("error", "")).lower()
+        return (
+            "unauthorized" in err
+            or "not logged" in err
+            or "session" in err
+        )
+
+    def _parse(resp):
+        try:
+            return resp.json()
+        except ValueError:
+            return None
 
     session = _get_session()
     resp = (session or requests).get(url, params=params, timeout=timeout)
+    body = _parse(resp)
 
-    if _is_auth_error(resp):
+    if _is_auth_error(resp, body):
         _log("Session vypršela během stahování – obnovuji přihlášení...",
              Qgis.MessageLevel.Warning)
         AMCR_SESSION = None  # Invalidate the old session
@@ -140,6 +158,7 @@ def _api_get(url, params, timeout=30) -> requests.Response:
             AMCR_SESSION = login_to_api(username, password)
             if AMCR_SESSION:
                 resp = AMCR_SESSION.get(url, params=params, timeout=timeout)
+                body = _parse(resp)
             else:
                 _log("Opakované přihlášení selhalo.",
                      Qgis.MessageLevel.Critical)
@@ -147,7 +166,11 @@ def _api_get(url, params, timeout=30) -> requests.Response:
             _log("Přihlašovací údaje nejsou uloženy – pokračuji anonymně.",
                  Qgis.MessageLevel.Warning)
 
-    return resp
+    if body is None:
+        raise ValueError(
+            f"API nevrátilo platný JSON (HTTP {resp.status_code})"
+        )
+    return body
 
 
 def load_translations():
@@ -165,7 +188,10 @@ def load_translations():
         if r.status_code == 200:
             TRANSLATIONS = r.json()
     except Exception as e:
-        print(f"Error downloading vocabulary: {e}")
+        QgsMessageLog.logMessage(
+            f"Error downloading vocabulary: {e}",
+            "AMČR", Qgis.MessageLevel.Warning
+        )
 
 
 def tr_code(code):
@@ -199,6 +225,16 @@ def load_amcr_data(canvas, bb, filters=None,
     2. Fetches metadata and geometries from API
     3. Creates QGIS memory layers and populates them with features
     """
+    global _LOADING
+    if _LOADING:
+        iface.messageBar().pushMessage(
+            "AMCR",
+            "Stahování již probíhá, počkejte na jeho dokončení.",
+            level=Qgis.MessageLevel.Warning
+        )
+        return
+    _LOADING = True
+
     load_translations()
 
     # --- 1. COORDINATE TRANSFORMATION ---
@@ -258,6 +294,7 @@ def load_amcr_data(canvas, bb, filters=None,
         MAX_LIMIT = 20000  # Safety limit to prevent QGIS from freezing
 
         seen_ids = set()
+        fetched_total = 0  # All downloaded records incl. duplicates
         target_pian_ids_count = 0
 
         # Check if we should skip negative results based on filter
@@ -280,14 +317,15 @@ def load_amcr_data(canvas, bb, filters=None,
                 del base_params['page']
 
             try:
-                resp_docs = _api_get(url, params=base_params, timeout=30)
-                resp_json = resp_docs.json()
+                resp_json = _api_get_json(url, params=base_params, timeout=30)
                 data = resp_json.get('response', {})
                 batch_docs = data.get('docs', [])
                 num_found = data.get('numFound', 0)
 
                 if not batch_docs:
                     break
+
+                fetched_total += len(batch_docs)
 
                 # Filter out duplicates and append to main list
                 new_docs = []
@@ -298,12 +336,16 @@ def load_amcr_data(canvas, bb, filters=None,
                         new_docs.append(d)
 
                 docs.extend(new_docs)
-                print(
+                QgsMessageLog.logMessage(
                     f"Strana {current_page} stažena. "
-                    f"Celkem záznamů: {len(docs)} / {num_found}"
+                    f"Celkem záznamů: {len(docs)} / {num_found}",
+                    "AMČR", Qgis.MessageLevel.Info
                 )
 
-                if len(docs) >= num_found:
+                # Compare downloaded (not unique) records against numFound –
+                # pages full of duplicates would otherwise trigger
+                # needless extra requests
+                if fetched_total >= num_found:
                     break
                 if len(docs) >= MAX_LIMIT:
                     iface.messageBar().pushMessage(
@@ -317,7 +359,10 @@ def load_amcr_data(canvas, bb, filters=None,
                 QApplication.processEvents()  # Keep UI responsive
 
             except Exception as e:
-                print(f"Chyba při stránkování na straně {current_page}: {e}")
+                QgsMessageLog.logMessage(
+                    f"Chyba při stránkování na straně {current_page}: {e}",
+                    "AMČR", Qgis.MessageLevel.Warning
+                )
                 break
 
         if not docs:
@@ -593,11 +638,13 @@ def load_amcr_data(canvas, bb, filters=None,
             }
             try:
                 QApplication.processEvents()
-                r_pian = _api_get(url, params=params_pian, timeout=15)
-                batch_docs = r_pian.json().get('response', {}).get('docs', [])
-                docs_pian.extend(batch_docs)
+                r_json = _api_get_json(url, params=params_pian, timeout=15)
+                docs_pian.extend(r_json.get('response', {}).get('docs', []))
             except Exception as e:
-                print(f"Chyba PIAN: {e}")
+                QgsMessageLog.logMessage(
+                    f"Chyba PIAN: {e}",
+                    "AMČR", Qgis.MessageLevel.Warning
+                )
 
         # ==========================================
         # D) LAYER CREATION (QGIS Memory Layers)
@@ -851,8 +898,10 @@ def load_amcr_data(canvas, bb, filters=None,
                             target_list.append(feat)
 
             except Exception as ex:
-                print(f"Chyba při tvorbě feature: {ex}")
-                pass
+                QgsMessageLog.logMessage(
+                    f"Chyba při tvorbě feature: {ex}",
+                    "AMČR", Qgis.MessageLevel.Warning
+                )
 
 # --- ADDING TO QGIS INTERFACE ---
         proj = QgsProject.instance()
@@ -892,5 +941,6 @@ def load_amcr_data(canvas, bb, filters=None,
             level=Qgis.MessageLevel.Critical
         )
     finally:
-        # Always restore cursor, even after failure
+        # Always restore cursor and release the guard, even after failure
+        _LOADING = False
         QApplication.restoreOverrideCursor()

--- a/amcr_viewer/amcr_tools.py
+++ b/amcr_viewer/amcr_tools.py
@@ -179,11 +179,12 @@ def tr_code(code):
 
 
 def komp_projde_filtrem(komp, filter_areal, filter_datace, filters):
-    areal_id = komp.get('komponenta_areal', {}).get('id', "")
+    # 'or {}' – the key may be present with a None value
+    areal_id = (komp.get('komponenta_areal') or {}).get('id', "")
     if filter_areal and areal_id not in filters.get('f_areal', []):
         return False
 
-    obdobi_id = komp.get('komponenta_obdobi', {}).get('id', "")
+    obdobi_id = (komp.get('komponenta_obdobi') or {}).get('id', "")
     if filter_datace and obdobi_id not in filters.get('f_obdobi', []):
         return False
 
@@ -361,8 +362,8 @@ def load_amcr_data(canvas, bb, filters=None,
 
             actions_with_geom += 1
 
-            # Extract protected fields
-            az_chranene = doc.get('az_chranene_udaje', {})
+            # Extract protected fields ('or {}' – key may hold None)
+            az_chranene = doc.get('az_chranene_udaje') or {}
             chranene = (
                 doc.get('akce_chranene_udaje')
                 or doc.get('lokalita_chranene_udaje')
@@ -518,13 +519,13 @@ def load_amcr_data(canvas, bb, filters=None,
                                             'ident_cely',
                                             ""
                                             ),
-                                        'komponenta_areal': komp.get(
-                                            'komponenta_areal',
-                                            {}
+                                        'komponenta_areal': (
+                                            komp.get('komponenta_areal')
+                                            or {}
                                         ).get('value', ""),
-                                        'komponenta_obdobi': komp.get(
-                                            'komponenta_obdobi',
-                                            {}
+                                        'komponenta_obdobi': (
+                                            komp.get('komponenta_obdobi')
+                                            or {}
                                         ).get('value', ""),
                                     }
                                     pian_lookup[dj_pian_value].append(komp_meta)
@@ -713,6 +714,14 @@ def load_amcr_data(canvas, bb, filters=None,
         # Lists to hold features before batch-adding to layers
         feats_p, feats_l, feats_pt = [], [], []
 
+        # Transform for PIANs that only provide WGS-84 geometry (geom_wkt) –
+        # the target layers are in S-JTSK (EPSG:5514)
+        xform_wgs_to_sjtsk = QgsCoordinateTransform(
+            QgsCoordinateReferenceSystem("EPSG:4326"),
+            QgsCoordinateReferenceSystem("EPSG:5514"),
+            QgsProject.instance()
+        )
+
         # --- FEATURE POPULATION ---
         for doc in docs_pian:
             try:
@@ -733,25 +742,46 @@ def load_amcr_data(canvas, bb, filters=None,
                 )
 
                 wkt = None
+                wkt_is_wgs = False
                 if jdata.get('geom_sjtsk_wkt'):
                     wkt = jdata.get('geom_sjtsk_wkt', {}).get('value')
                 elif jdata.get('geom_wkt'):
+                    # Fallback geometry is in WGS-84 and must be
+                    # transformed to S-JTSK before use
                     wkt = jdata.get('geom_wkt', {}).get('value')
+                    wkt_is_wgs = True
 
-                pian_presnost = tr_code(str(doc.get('pian_presnost', '')))
-                pian_typ = tr_code(str(doc.get('pian_typ', '')))
+                # The API may return the value as a single-item list –
+                # normalize before comparing against filter codes
+                raw_presnost = doc.get('pian_presnost', '')
+                if isinstance(raw_presnost, list):
+                    raw_presnost = raw_presnost[0] if raw_presnost else ''
+                raw_typ = doc.get('pian_typ', '')
+                if isinstance(raw_typ, list):
+                    raw_typ = raw_typ[0] if raw_typ else ''
+
+                pian_presnost = tr_code(str(raw_presnost))
+                pian_typ = tr_code(str(raw_typ))
 
                 # Final precision filter check
                 if (
                     filters
                     and filters.get('f_pian_presnost')
-                    and doc.get('pian_presnost')
+                    and str(raw_presnost)
                     not in filters.get('f_pian_presnost')
                 ):
                     continue
 
                 if wkt:
                     geom = QgsGeometry.fromWkt(wkt)
+                    if geom.isNull():
+                        continue
+                    if wkt_is_wgs:
+                        geom.transform(xform_wgs_to_sjtsk)
+                    if not geom.isGeosValid():
+                        # Try to repair (e.g. self-intersections)
+                        # instead of silently dropping the feature
+                        geom = geom.makeValid()
                     if geom.isGeosValid():
                         t = geom.type()
                         target_list = None

--- a/amcr_viewer/amcr_tools.py
+++ b/amcr_viewer/amcr_tools.py
@@ -308,6 +308,10 @@ def load_amcr_data(canvas, bb, filters=None,
         filter_areal = "f_areal" in filters if filters else False
         filter_datace = "f_obdobi" in filters if filters else False
 
+        # Set when a network error interrupts the download – the user
+        # gets an explicit error/warning instead of a silent partial result
+        network_error = False
+
         # --- API PAGINATION LOOP ---
         while True:
             base_params['rows'] = BATCH_DOCS
@@ -358,12 +362,29 @@ def load_amcr_data(canvas, bb, filters=None,
                 current_page += 1
                 QApplication.processEvents()  # Keep UI responsive
 
+            except requests.exceptions.RequestException as e:
+                network_error = True
+                QgsMessageLog.logMessage(
+                    f"Chyba sítě při stránkování na straně "
+                    f"{current_page}: {e}",
+                    "AMČR", Qgis.MessageLevel.Critical
+                )
+                break
             except Exception as e:
                 QgsMessageLog.logMessage(
                     f"Chyba při stránkování na straně {current_page}: {e}",
                     "AMČR", Qgis.MessageLevel.Warning
                 )
                 break
+
+        if network_error and not docs:
+            iface.messageBar().pushMessage(
+                "AMCR",
+                "Stahování selhalo: chyba sítě. "
+                "Zkontrolujte připojení k internetu.",
+                level=Qgis.MessageLevel.Critical
+            )
+            return
 
         if not docs:
             iface.messageBar().pushMessage(
@@ -640,6 +661,15 @@ def load_amcr_data(canvas, bb, filters=None,
                 QApplication.processEvents()
                 r_json = _api_get_json(url, params=params_pian, timeout=15)
                 docs_pian.extend(r_json.get('response', {}).get('docs', []))
+            except requests.exceptions.RequestException as e:
+                # Network is down – stop immediately instead of
+                # uselessly retrying every remaining batch
+                network_error = True
+                QgsMessageLog.logMessage(
+                    f"Chyba sítě při stahování geometrií PIAN: {e}",
+                    "AMČR", Qgis.MessageLevel.Critical
+                )
+                break
             except Exception as e:
                 QgsMessageLog.logMessage(
                     f"Chyba PIAN: {e}",
@@ -920,7 +950,19 @@ def load_amcr_data(canvas, bb, filters=None,
                 proj.addMapLayer(l)
                 added += len(f)
 
-        if added > 0:
+        if network_error:
+            iface.messageBar().pushMessage(
+                "AMCR",
+                "Stahování bylo přerušeno chybou sítě – "
+                f"výsledek je neúplný (vykresleno {added} prvků). "
+                "Zkontrolujte připojení a spusťte stahování znovu.",
+                level=(
+                    Qgis.MessageLevel.Warning
+                    if added > 0
+                    else Qgis.MessageLevel.Critical
+                )
+            )
+        elif added > 0:
             iface.messageBar().pushMessage(
                 "AMCR",
                 f"Hotovo. Záznamů: {len(docs)} (s geom: {actions_with_geom}). "

--- a/amcr_viewer/amcr_tools.py
+++ b/amcr_viewer/amcr_tools.py
@@ -17,6 +17,10 @@ TRANSLATIONS = {}
 # None = not logged in (anonymous access)
 AMCR_SESSION: requests.Session | None = None
 
+# Reason of the last failed login: 'auth' (wrong credentials),
+# 'network' (server unreachable / invalid response) or None
+LAST_LOGIN_ERROR: str | None = None
+
 # Re-entrancy guard: the download runs in the main thread and pumps the
 # event loop via processEvents(), so the user could otherwise start
 # a second download while the first one is still running
@@ -38,6 +42,9 @@ def login_to_api(username: str, password: str):
     """
     login_url = "https://digiarchiv.aiscr.cz/api/user/login"
 
+    global LAST_LOGIN_ERROR
+    LAST_LOGIN_ERROR = None
+
     _log(f"Přihlašuji uživatele: '{username}'")
 
     if not username or not password:
@@ -45,6 +52,7 @@ def login_to_api(username: str, password: str):
             "CHYBA: username nebo heslo je prázdné.",
             Qgis.MessageLevel.Critical
         )
+        LAST_LOGIN_ERROR = 'auth'
         return None
 
     session = requests.Session()
@@ -72,6 +80,7 @@ def login_to_api(username: str, password: str):
                 f"CHYBA přihlášení (API): {body['error']}",
                 Qgis.MessageLevel.Critical
             )
+            LAST_LOGIN_ERROR = 'auth'
             return None
 
         _log("Přihlášení proběhlo úspěšně.")
@@ -80,18 +89,22 @@ def login_to_api(username: str, password: str):
         return session
 
     except requests.exceptions.HTTPError as e:
-        _log(f"CHYBA HTTP {e.response.status_code if e.response else '?'}: "
-             f"{e.response.text[:300] if e.response else 'žádná odpověď'}",
+        status = e.response.status_code if e.response is not None else None
+        _log(f"CHYBA HTTP {status if status else '?'}: "
+             f"{e.response.text[:300] if e.response is not None else 'žádná odpověď'}",
              Qgis.MessageLevel.Critical)
+        LAST_LOGIN_ERROR = 'auth' if status in (401, 403) else 'network'
         return None
     except requests.exceptions.RequestException as e:
         _log(f"CHYBA sítě: {e}", Qgis.MessageLevel.Critical)
+        LAST_LOGIN_ERROR = 'network'
         return None
     except ValueError:
         # Server returned non-JSON (e.g. an HTML error page behind a proxy)
         _log("CHYBA: server nevrátil platný JSON: "
              f"{response.text[:300]}",
              Qgis.MessageLevel.Critical)
+        LAST_LOGIN_ERROR = 'network'
         return None
 
 

--- a/amcr_viewer/amcr_viewer.py
+++ b/amcr_viewer/amcr_viewer.py
@@ -6,7 +6,6 @@ from qgis.core import Qgis
 
 from .amcr_tools import load_amcr_data, login_to_api
 from .amcr_dialog import AmcrFilterDialog, LoginDialog
-from .resources import *
 import os.path
 
 
@@ -24,8 +23,9 @@ class AmcrViewer:
         self.iface = iface
         self.plugin_dir = os.path.dirname(__file__)
 
-        # Determine the user's locale to load appropriate translation files
-        locale = QSettings().value('locale/userLocale')[0:2]
+        # Determine the user's locale to load appropriate translation files.
+        # The setting may be missing (None) on a fresh QGIS install.
+        locale = str(QSettings().value('locale/userLocale') or 'en')[0:2]
         locale_path = os.path.join(
             self.plugin_dir,
             'i18n',

--- a/amcr_viewer/metadata.txt
+++ b/amcr_viewer/metadata.txt
@@ -47,7 +47,7 @@ tags=python,AMCR,AIS CR,archaeology,PIAN,AMČR,archeologie
 
 homepage=https://amcr-help.aiscr.cz/digiarchiv/qgis-viewer.html
 category=Vector
-icon=download.png
+icon=akce.png
 # experimental flag
 experimental=False
 


### PR DESCRIPTION
## Opravy chyb a optimalizace napříč pluginem

Tento PR vychází z revize celého kódu pluginu a opravuje nalezené chyby, doplňuje ošetření chybových stavů a aktualizuje release workflow. Změny jsou rozdělené do 8 commitů po logických celcích; funkční rozsah pluginu se nemění.

### 🔴 Opravy pádů

- **Pád při startu QGIS bez nastaveného locale** — `QSettings().value('locale/userLocale')` může být na čisté instalaci `None`; plugin pak spadl na `TypeError` hned při načtení. Doplněn fallback na `'en'`.
- **Pády u úlohy „Aktualizovat hesláře“** — Python wrapper `QgsTask` se nově drží v modulové referenci (GC ho dříve mohl uklidit před dokončením úlohy → pád QGIS); závěrečné message boxy se parentují na hlavní okno místo dialogu, který může být v době dokončení už zavřený; tlačítko se během běhu zakáže, takže nelze spustit víc aktualizací paralelně přepisujících `heslar.csv`.

### 🟠 Opravy datové korektnosti

- **Geometrie ve WGS-84 ve vrstvě S-JTSK** — fallback z `geom_wkt` se nyní transformuje do EPSG:5514; dříve se souřadnice ve stupních vkládaly přímo do vrstvy v S-JTSK a prvek se vykreslil zcela mimo území ČR.
- **Nevalidní geometrie** (např. samoprůniky polygonů) se před zahozením zkusí opravit přes `makeValid()`.
- **Filtr přesnosti PIAN** mohl tiše zahazovat záznamy, pokud API vrátilo `pian_presnost` jako jednoprvkový seznam — hodnota se nyní normalizuje (totéž pro `pian_typ`).
- **Heslář přístupnosti** — záznamy bez platného jednopísmenného kódu se při aktualizaci heslářů přeskakují; do CSV a následně do API filtru už nepropadne hodnota `None`.
- Přístupy ke `komponenta_areal`, `komponenta_obdobi` a `az_chranene_udaje` ošetřeny proti klíči s hodnotou `null`.

### 🟡 Robustnost přihlašování a stahování

- **Ověření přihlašovacích údajů před uložením** — dialog zkusí přihlášení k API ještě před zápisem do správce autentizace QGIS; neplatné údaje se neuloží a uživatel je může rovnou opravit. Při nedostupném serveru se lze rozhodnout uložit je neověřené.
- **Zřetelné hlášení síťových chyb** — výpadek sítě uprostřed stahování dříve skončil jen záznamem v logu a hláškou „Žádná data k zobrazení“; nyní se stahování geometrií po první síťové chybě ihned ukončí a uživatel dostane červenou lištu (nic nestaženo), resp. varování o neúplném výsledku (částečná data).
- Ošetřena ne-JSON odpověď serveru při loginu; tělo API odpovědi se parsuje jen jednou (dříve dvakrát na každé dávce); stránkování porovnává počet stažených záznamů proti `numFound`, takže stránky plné duplicit negenerují requesty navíc; přidán guard proti spuštění druhého stahování během běžícího; `print()` sjednoceno na `QgsMessageLog` (záložka AMČR).

### ⚙️ Metadata a CI

- `metadata.txt`: `icon` ukazoval na neexistující `download.png` → nastaveno na `akce.png` (plugin měl ve správci modulů prázdnou ikonu).
- Release workflow: akce aktualizovány na `actions/checkout` v6.0.3 a `softprops/action-gh-release` v3.0.0 a připnuty na commit hash (řeší CodeQL alert „Unpinned tag for a non-immutable Action“; chrání pipeline před přepsáním tagu třetí stranou).
- README: poznámka, že `requests` nemusí být na Linuxu součástí systémové instalace QGIS; drobné odstranění nepoužitého importu.

### Mimo rozsah (vědomě)

Přesun celého stahování dat z hlavního vlákna do `QgsTask` by byl největším dalším zlepšením odezvy UI, ale jde o větší refaktor (tvorba vrstev musí zůstat v hlavním vlákně) — ponecháno na samostatný PR. Nejhorší symptom (souběžná stahování) mezitím řeší re-entrancy guard.

### Testování

Provedeno ruční testování v QGIS dle checklistu níže — pokryty běžné scénáře i hraniční případy (výpadek sítě, expirovaná session, špatné heslo, zrušení úlohy, prázdné výsledky, limit 20 000 záznamů). Neodškrtnuté položky jsou datově vzácné případy (PIAN pouze s WGS geometrií, nevalidní polygony) a ověření workflow při příštím releasu.


## Pokyny pro testování

Testuj v QGIS 3.44+ s nainstalovanou upravenou verzí pluginu (zabal `amcr_viewer/` do ZIPu a nainstaluj přes „Install from ZIP“). Před testem otevři **panel Zprávy → záložka AMČR** — nově tam jde většina logování.

### 1. Start pluginu a locale

**Co se změnilo:** fallback `'en'` při chybějícím `locale/userLocale`, odstraněný import resources.

- [x] **Základní:** Restartuj QGIS s nainstalovaným pluginem — musí se načíst bez chyby, ikona v toolbaru funguje.
- [x] **Hraniční case (hlavní):** Simuluj čistou instalaci — v Nastavení → Možnosti → Obecné vypni „Přepsat systémové národní prostředí“, nebo natvrdo: v Python konzoli `QSettings().remove('locale/userLocale')` a restartuj QGIS. Před opravou plugin spadl na `TypeError` hned při načtení; teď se musí načíst normálně.

### 2. Aktualizace heslářů (QgsTask)

**Co se změnilo:** držení reference na task, zákaz tlačítka během běhu, message boxy parentované na hlavní okno.

- [x] **Základní:** Otevři filtr dialog → „Aktualizovat hesláře 🔄“. Tlačítko musí okamžitě **zešedivět**. Po doběhnutí (pár minut) přijde messagebox „Hotovo“ a tlačítko se znovu povolí.
- [x] **Hraniční case 1 — zavření dialogu během běhu:** Spusť aktualizaci a hned dialog zavři (Cancel / křížek). Pracuj dál s QGIS. Po doběhnutí úlohy se messagebox musí zobrazit nad hlavním oknem QGIS a **QGIS nesmí spadnout**. (Tohle byl dřív pád na smazaném C++ objektu.)
- [x] **Hraniční case 2 — dvojklik:** Zkus rychle kliknout na tlačítko dvakrát — druhý klik nesmí projít (tlačítko je zakázané), v task manageru (kolečko vpravo dole) běží jen jedna úloha.
- [x] **Hraniční case 3 — zrušení:** Spusť aktualizaci a zruš ji přes task manager QGIS. Musí přijít hláška „Aktualizace byla zrušena uživatelem“ a tlačítko se znovu povolit.
- [x] **Hraniční case 4 — chyba zápisu:** Nastav `codelists/heslar.csv` jen pro čtení (Windows: vlastnosti souboru; Linux: `chmod 444`) a spusť aktualizaci. Musí přijít messagebox s konkrétní chybou (PermissionError), ne tichý pád.

### 3. Geometrie — WGS-84 fallback a makeValid

**Co se změnilo:** `geom_wkt` (WGS-84) se transformuje do S-JTSK; nevalidní geometrie se opravují místo zahození.

- [x] **Základní regrese:** Stáhni akce v menším území (např. katastr s pár desítkami záznamů) a vizuálně ověř, že polygony/linie/body sedí na podkladovou mapu — tj. že transformace nic nerozbila u běžných záznamů s `geom_sjtsk_wkt`.
- [ ] **Hraniční case — PIAN jen s WGS geometrií:** Tohle je datově vzácné a těžko se hledá naslepo. Nejjednodušší ověření: do `amcr_tools.py` dočasně přidej log do větve `elif jdata.get('geom_wkt')` a stáhni větší území. Pokud se větev trefí, prvek se musí vykreslit **uvnitř ČR**, ne u nulového poledníku (před opravou byl prvek „u Afriky“ — souřadnice ve stupních ve vrstvě EPSG:5514). Pomocný trik: po stažení dej vrstvě „Přiblížit na vrstvu“ — pokud extent obsáhne půl zeměkoule, něco je špatně.
- [ ] **Hraniční case — nevalidní polygon:** Opět spíš statistický test: stáhni velké území (celý okres, polygonové PIANy) před a po opravě a porovnej počet prvků v polygonové vrstvě — po opravě by měl být stejný nebo vyšší (opravené samoprůniky se už nezahazují). V záložce AMČR nesmí přibýt chyby „Chyba při tvorbě feature“.

### 4. Filtr přesnosti PIAN

**Co se změnilo:** normalizace hodnoty, která může z API přijít jako seznam.

- [x] **Základní:** Výchozí stav (předvybrané 3 přesnosti) — stáhni území a ověř, že se prvky vykreslují a sloupec „Přesnost“ je vyplněný českým textem (ne kódem `HES-…` ani `['HES-…']`).
- [x] **Hraniční case 1:** Vyber **jen jednu** přesnost (např. „odchylka jednotky metrů“) a srovnej počet prvků s během se všemi přesnostmi — musí být menší/roven a sloupec Přesnost musí obsahovat jen vybranou hodnotu.
- [x] **Hraniční case 2:** Přidej k výběru „vymezeno katastrem“ (4. hodnota) — prvky typu katastrální území se musí objevit.

### 5. Síťová vrstva a stahování

**Co se změnilo:** ošetření ne-JSON odpovědí, jedno parsování, počítání stažených záznamů, re-entrancy guard, logování do QgsMessageLog.

- [x] **Základní:** Běžné stažení akcí i lokalit, s přihlášením i anonymně. V záložce AMČR sleduj průběh stránkování („Strana X stažena…“) — dřív to šlo jen do konzole.
- [x] **Hraniční case 1 — klik během stahování:** Spusť stahování většího území a **během něj** klikni znovu na „Stáhnout data akcí“. Musí se objevit žlutá lišta „Stahování již probíhá…“ a druhé stahování se nesmí rozjet. Po dokončení prvního musí jít spustit nové (guard se uvolnil) — ověř i po stažení, které skončí chybou.
- [x] **Hraniční case 2 — výpadek sítě:** Odpoj síť uprostřed stahování. Plugin musí skončit červenou lištou s chybou, kurzor se musí vrátit z přesýpacích hodin a další stahování musí jít spustit.
- [x] **Hraniční case 3 — expirovaná session:** Přihlas se, stáhni data, pak v Digiarchivu (web) se odhlas/změň heslo, nebo počkej na expiraci, a stáhni znovu. V logu má být „Session vypršela… obnovuji přihlášení“ a stahování má doběhnout.
- [x] **Hraniční case 4 — špatné heslo:** Ulož záměrně špatné heslo a zkus stáhnout neveřejná data. Musí přijít srozumitelná chyba do záložky „AMČR login“, ne traceback.
- [x] **Hraniční case 5 — prázdný výsledek:** Nastav filtr bez výsledků (např. exotická kombinace katastr + období). Lišta „Žádné záznamy nenalezeny“, žádné vrstvy, kurzor v pořádku.
- [x] **Hraniční case 6 — limit 20 000:** Vypni bounding box a stáhni vše bez filtru. Musí se objevit varování o dosažení limitu a QGIS nesmí zamrznout trvale.
- [ ] **Hraniční case 7 — záznamy bez geometrie:** Filtr, který vrátí jen záznamy bez PIANu → lišta „Nalezeno X záznamů, ale žádný nemá geometrii“.

### 6. Heslář přístupnost

**Co se změnilo:** záznamy bez jednopísmenného kódu se při aktualizaci heslářů přeskakují.

- [x] Po doběhnutí aktualizace heslářů otevři `codelists/heslar.csv` a zkontroluj řádky s kategorií `pristupnost`: každý musí mít ve sloupci Kód právě jedno písmeno (A–E), žádný prázdný ani `None`.
- [x] V dialogu pak otevři picker „Přístupnost“, vyber hodnotu a stáhni data — sloupec Přístupnost ve výsledku musí odpovídat.

### 7. Metadata a CI

- [x] **Ikona:** Ve Správci zásuvných modulů musí mít plugin ikonu (akce.png) — předtím prázdné místo.
- [ ] **Workflow:** Ověří se až při příštím release — po publikování releasu zkontroluj, že Action doběhla zeleně a ZIP je přiložený.

### Doporučené pořadí

Nejdřív rychlé smoke testy (1, 7-ikona, základní stažení akcí/lokalit s i bez komponent — **komponenty otestuj zvlášť**, sahal jsem na None-ošetření `komponenta_areal/obdobi`, takže ověř, že sloupce Areál/Období se plní a prázdné komponenty nepadají), pak edge casy u stahování (5), pak hesláře (2, 6), nakonec datově vzácné geometrické casy (3).