### PR TITLE
feature/projektové akce: filtrování a sloupec Projekt v akcích

### DIFF
--- a/amcr_viewer/amcr_dialog.py
+++ b/amcr_viewer/amcr_dialog.py
@@ -169,6 +169,8 @@ class AmcrFilterDialog(QDialog):
         if self.typ_dat == "akce":
             self.chk_posevidence = QCheckBox("Pouze pozitivní zjištění")
             layout.addWidget(self.chk_posevidence)
+            self.chk_proj_akce = QCheckBox("Pouze projektové akce")
+            layout.addWidget(self.chk_proj_akce)
 
         layout.addSpacing(10)
 
@@ -453,6 +455,8 @@ class AmcrFilterDialog(QDialog):
         if self.typ_dat == "akce":
             if self.chk_posevidence.isChecked():
                 filters['posevidence'] = 'true'
+            if self.chk_proj_akce.isChecked():
+                filters['proj_akce'] = 'true'
             if self.selection_cache['organizace']:
                 filters['f_organizace'] = self.selection_cache['organizace']
             if self.selection_cache['typ_akce']:

--- a/amcr_viewer/amcr_tools.py
+++ b/amcr_viewer/amcr_tools.py
@@ -317,6 +317,12 @@ def load_amcr_data(canvas, bb, filters=None,
             else False
         )
 
+        only_projektove_akce = (
+            filters.get('proj_akce') == 'true'
+            if filters
+            else False
+        )
+
         # Check whether we should filter results based on component filters
         filter_areal = "f_areal" in filters if filters else False
         filter_datace = "f_obdobi" in filters if filters else False
@@ -437,6 +443,9 @@ def load_amcr_data(canvas, bb, filters=None,
         for doc in docs:
             piani = doc.get('az_dj_pian', [])
             if not piani:
+                continue
+
+            if only_projektove_akce and not doc.get("akce_projekt", False):
                 continue
 
             actions_with_geom += 1

--- a/amcr_viewer/amcr_tools.py
+++ b/amcr_viewer/amcr_tools.py
@@ -524,6 +524,11 @@ def load_amcr_data(canvas, bb, filters=None,
                         if doc.get('akce_je_nz') is True
                         else "Ne"
                     ),
+                    "projekt": g(
+                        doc,
+                        'akce_projekt',
+                        ""
+                    ),
                 })
 
             elif typ_dat == "lokalita":
@@ -750,6 +755,7 @@ def load_amcr_data(canvas, bb, filters=None,
                 QgsField("vedlejsi_typ", QMetaType.Type.QString),
                 QgsField("zjisteni", QMetaType.Type.QString),
                 QgsField("nahrazuje_NZ", QMetaType.Type.QString),
+                QgsField("projekt", QMetaType.Type.QString),
             ]
         elif typ_dat == "lokalita":
             cols += [
@@ -793,6 +799,7 @@ def load_amcr_data(canvas, bb, filters=None,
             "komponenta": "Komponenta",
             "komponenta_areal": "Areál",
             "komponenta_obdobi": "Období",
+            "projekt": "Projekt",
         }
 
         if komponenty == "true":
@@ -926,7 +933,8 @@ def load_amcr_data(canvas, bb, filters=None,
                                     meta['akce_hlavni_typ'],
                                     meta['akce_vedlejsi_typ'],
                                     meta['dj_negativni'],
-                                    meta['akce_je_nz']
+                                    meta['akce_je_nz'],
+                                    meta['projekt'],
                                 ])
                             else:
                                 atributy.extend([


### PR DESCRIPTION
## Souhrn

Přidává podporu pro **projektové akce** ve vrstvě „akce":

- Do dialogu filtru akcí přibyl checkbox **„Pouze projektové akce"**, kterým lze omezit výsledky jen na projektové akce.
- Do atributové tabulky akcí přibyl sloupec **Projekt**. Hodnota je vyplněná z pole `akce_projekt`; pokud nejde o projektovou akci, zůstává prázdná.

## Změny

**`amcr_viewer/amcr_dialog.py`**
- Nový checkbox `chk_proj_akce` („Pouze projektové akce") v dialogu pro typ dat `akce`.
- Při zaškrtnutí se do filtrů přidá `proj_akce='true'`.

**`amcr_viewer/amcr_tools.py`**
- Vyhodnocení filtru `proj_akce`: dokumenty bez `akce_projekt` se přeskočí.
- Nové pole `projekt` v metadatech akce (z `akce_projekt`, výchozí prázdný řetězec).
- Přidán sloupec `QgsField("projekt", …)` do definice atributů akcí.
- Doplněn překlad hlavičky sloupce `projekt → "Projekt"`.
- Hodnota `projekt` zařazena do exportu atributů.

## Poznámky k testování
- Otevřít dialog filtru akcí → ověřit přítomnost checkboxu „Pouze projektové akce".
- Se zaškrtnutým checkboxem se zobrazí pouze projektové akce.
- V atributové tabulce akcí je sloupec **Projekt** vyplněný u projektových akcí, jinak prázdný.